### PR TITLE
Adding `error`

### DIFF
--- a/cmd/internal/gendone/main.go
+++ b/cmd/internal/gendone/main.go
@@ -22,7 +22,10 @@ func main() {
 			"ctx.Done()":          "done",
 			"\"context\"\n\t":     "", // meybe better to use goimports?
 			`//go:generate go run ./cmd/internal/gendone/`: "",
-			`or context cancelled.`:                        "or done is closed",
+			`ctx == nil`:            `done == nil`,
+			`ErrContext`:            `ErrDone`,
+			`nil Contex`:            `nil done chan`,
+			`or context cancelled.`: "or done is closed",
 		}
 
 		for _, search := range sortKeyDesc(replacements) {
@@ -43,8 +46,9 @@ func main() {
 		}
 
 		replacements := map[string]string{
-			"WithContext(t *testing.T":     "WithDone(t *testing.T",
-			"WithContext(ctx":              "WithDone(done",
+
+			"WithContext(":                 "WithDone(",
+			"WithContextNil(":              "WithDoneNil(",
 			"testTableContext":             "testTableDone",
 			"ctx, cancel := test.fncCtx()": "done, cancel := test.fncDone()",
 			"<-ctx.Done()":                 "<-done",
@@ -52,6 +56,7 @@ func main() {
 			"ctx,":                         "done,",
 			"\"context\"\n\t":              "", // meybe better to use goimports?
 			`//go:generate go run ./cmd/internal/gendone/`: "",
+			`ErrContext`: `ErrDone`,
 		}
 		for _, search := range sortKeyDesc(replacements) {
 			data = bytes.ReplaceAll(data, []byte(search), []byte(replacements[search]))

--- a/examples_test.go
+++ b/examples_test.go
@@ -18,9 +18,6 @@ import (
 	"github.com/butuzov/harmony"
 )
 
-// --- Bridge Pattern Example --------------------------------------------------
-
-// --- Fan-in Pattern Example --------------------------------------------------
 func ExampleFanInWithContext() {
 	// return channel that generate
 	filler := func(start, stop int) chan int {
@@ -47,8 +44,6 @@ func ExampleFanInWithContext() {
 		}
 	}
 }
-
-// --- Future Pattern Example --------------------------------------------------
 
 // FututeWithContext is shows creation of two "futures" that are used in our
 // "rate our dogs" startup.
@@ -104,8 +99,6 @@ func ExampleFututeWithContext() {
 	// Output: 1 0
 }
 
-// --- OrDone Pattern Example --------------------------------------------------
-
 // ExampleOrWithContext - shows how many fibonacci sequence numbers we can
 // generate in one millisecond.
 func ExampleOrWithContext_Fibonacci() {
@@ -144,7 +137,6 @@ func ExampleOrWithContext_Fibonacci() {
 	}
 }
 
-// --- Pipeline Pattern Example ------------------------------------------------
 func ExamplePipelineWithContext_Primes() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -189,8 +181,6 @@ func ExamplePipelineWithContext_Primes() {
 	}
 }
 
-// --- Queue Pattern Example ---------------------------------------------------
-
 // Generate fibonacci sequence
 func ExampleQueueWithContext() {
 	// fin returns function  that returns Fibonacci sequence up to n element,
@@ -222,8 +212,6 @@ func ExampleQueueWithContext() {
 	fmt.Println(first10FibNumbers)
 	// Output: [1 1 2 3 5 8 13 21 34 55]
 }
-
-// --- Tee Pattern Example -----------------------------------------------------
 
 func ExampleTeeWithDone() {
 	done := make(chan struct{})
@@ -259,8 +247,6 @@ func ExampleTeeWithDone() {
 	fmt.Printf("Sequence sum is %d. Sequence product is %d", sum, prod)
 	// Output: Sequence sum is 55. Sequence product is 3628800
 }
-
-// --- WorkerPool Pattern  Example ---------------------------------------------
 
 func ExampleWorkerPoolWithContext_Primes() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
@@ -314,8 +300,8 @@ func ExampleWorkerPoolWithContext_Primes() {
 
 // Other Examples
 
-// What SQRT funtion is faster? Complex example that shows combination of few
-// patterns Queue, Tee, FanIn patterns.
+// What SQRT funtion is faster? Complex example that shows the combination of
+// few patterns Queue, Tee, FanIn patterns.
 func Example_fastestSqrt() {
 	// the fastert square root cracker....
 	type Report struct {

--- a/examples_test.go
+++ b/examples_test.go
@@ -41,8 +41,10 @@ func ExampleFanInWithContext() {
 	ch3 := filler(15, 16)
 
 	ctx := context.Background()
-	for val := range harmony.FanInWithContext(ctx, ch1, ch2, ch3) {
-		fmt.Println(val)
+	if ch, err := harmony.FanInWithContext(ctx, ch1, ch2, ch3); err != nil {
+		for val := range ch {
+			fmt.Println(val)
+		}
 	}
 }
 
@@ -81,13 +83,13 @@ func ExampleFututeWithContext_dogs_as_service() {
 		return data.Message
 	}
 
-	a := harmony.FututeWithContext(context.Background(), func() string {
+	a, _ := harmony.FututeWithContext(context.Background(), func() string {
 		return getRandomDogPicture()
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 	defer cancel()
-	b := harmony.FututeWithContext(ctx, func() string {
+	b, _ := harmony.FututeWithContext(ctx, func() string {
 		return getRandomDogPicture()
 	})
 	fmt.Printf("Rate My Dog: \n\ta) %s\n\tb) %s\n", <-a, <-b)
@@ -96,8 +98,8 @@ func ExampleFututeWithContext_dogs_as_service() {
 func ExampleFututeWithContext() {
 	// Requests random dogs picture from dog.ceo (dog as service)
 	ctx := context.Background()
-	a := harmony.FututeWithContext(ctx, func() int { return 1 })
-	b := harmony.FututeWithContext(ctx, func() int { return 0 })
+	a, _ := harmony.FututeWithContext(ctx, func() int { return 1 })
+	b, _ := harmony.FututeWithContext(ctx, func() int { return 0 })
 	fmt.Println(<-a, <-b)
 	// Output: 1 0
 }
@@ -132,11 +134,14 @@ func ExampleOrWithContext_Fibonacci() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
-	for val := range harmony.OrWithContext(ctx, incoming) {
-		results = append(results, val)
+	if ch, err := harmony.OrWithContext(ctx, incoming); err == nil {
+		for val := range ch {
+			results = append(results, val)
+		}
+		fmt.Println(results)
+	} else {
+		log.Printf("Error: %v", err)
 	}
-
-	fmt.Println(results)
 }
 
 // --- Pipeline Pattern Example ------------------------------------------------
@@ -171,15 +176,17 @@ func ExamplePipelineWithContext_Primes() {
 		}
 	}()
 
-	for val := range harmony.PipelineWithContext(ctx, incomingCh, 100, workerFunc) {
-		if val == 0 {
-			continue
+	if ch, err := harmony.PipelineWithContext(ctx, incomingCh, 100, workerFunc); err != nil {
+		log.Printf("Error: %v", err)
+	} else {
+		for val := range ch {
+			if val == 0 {
+				continue
+			}
+			results = append(results, val)
 		}
-
-		results = append(results, val)
+		fmt.Println(results)
 	}
-
-	fmt.Println(results)
 }
 
 // --- Queue Pattern Example ---------------------------------------------------
@@ -202,7 +209,12 @@ func ExampleQueueWithContext() {
 	}
 
 	first10FibNumbers := make([]int, 10)
-	incoming := harmony.QueueWithContext(context.Background(), fib(10))
+	incoming, err := harmony.QueueWithContext(context.Background(), fib(10))
+	if err != nil {
+		log.Printf("err: %v", err)
+		return
+	}
+
 	for i := 0; i < cap(first10FibNumbers); i++ {
 		first10FibNumbers[i] = <-incoming
 	}
@@ -217,7 +229,7 @@ func ExampleTeeWithDone() {
 	done := make(chan struct{})
 	pipe := make(chan int)
 
-	ch1, ch2 := harmony.TeeWithDone(done, pipe)
+	ch1, ch2, _ := harmony.TeeWithDone(done, pipe)
 
 	// generator
 	go func() {
@@ -354,18 +366,24 @@ func Example_fastestSqrt() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch := harmony.FututeWithContext(ctx, func() uint64 {
+	ch, _ := harmony.FututeWithContext(ctx, func() uint64 {
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		v := r.Uint64()
 		fmt.Printf("Initial number: %d\n", v)
 		return v
 	})
 
-	ch1, ch2 := harmony.TeeWithContext(ctx, ch)
+	if ch1, ch2, err := harmony.TeeWithContext(ctx, ch); err == nil {
+		log.Printf("err: %v", err)
+		return
+	} else {
+		chRep1, _ := harmony.PipelineWithContext(ctx, ch1, 1, sqrtBabylonian)
+		chRep2, _ := harmony.PipelineWithContext(ctx, ch2, 1, sqrtBakhshali)
 
-	out := harmony.FanInWithContext(ctx,
-		harmony.OrWithContext(ctx, harmony.PipelineWithContext(ctx, ch1, 1, sqrtBabylonian)),
-		harmony.OrWithContext(ctx, harmony.PipelineWithContext(ctx, ch2, 1, sqrtBakhshali)),
-	)
-	fmt.Printf("Result is :%v", <-out)
+		chRep1, _ = harmony.OrWithContext(ctx, chRep1)
+		chRep2, _ = harmony.OrWithContext(ctx, chRep2)
+
+		out, _ := harmony.FanInWithContext(ctx, chRep1, chRep2)
+		fmt.Printf("Result is :%v", <-out)
+	}
 }

--- a/with_context.go
+++ b/with_context.go
@@ -4,17 +4,27 @@ package harmony
 
 import (
 	"context"
+	"errors"
 	"sync"
 )
+
+var ErrContext = errors.New("harmony: nil Context")
 
 // --- Bridge Pattern  ---------------------------------------------------------
 
 // BridgeWithContext will return chan of generic type `T` used a pipe for the
-// values received from the sequence of channels. Close channel (received from
-// `incoming`) in order to  switch for a new one. Goroutines exists on close of
-// `incoming` or context canceled.
-func BridgeWithContext[T any](ctx context.Context, incoming <-chan (<-chan T)) <-chan T {
+// values received from the sequence of channels or `ErrContext`. Close received
+// channel (one you got from`incoming`) in order to switch for a new one.
+// Goroutines exists on close of `incoming` or context canceled.
+func BridgeWithContext[T any](
+	ctx context.Context,
+	incoming <-chan (<-chan T),
+) (<-chan T, error) {
 	outgoing := make(chan T)
+
+	if ctx == nil {
+		return nil, ErrContext
+	}
 
 	go func() {
 		defer close(outgoing)
@@ -33,16 +43,17 @@ func BridgeWithContext[T any](ctx context.Context, incoming <-chan (<-chan T)) <
 				stream = tmp
 			}
 
-			// now we ae trying to actually read from channel, and pass value next to
+			// Now we are trying to actually read from channel, and pass value next to
 			// its receive channel, if fail to read back to new iteration of this
 			// loop.
-			for val := range OrWithContext(ctx, stream) {
+			ch, _ := OrWithContext(ctx, stream)
+			for val := range ch {
 				outgoing <- val
 			}
 		}
 	}()
 
-	return outgoing
+	return outgoing, nil
 }
 
 // --- Fan-in Pattern  ---------------------------------------------------------
@@ -50,7 +61,11 @@ func BridgeWithContext[T any](ctx context.Context, incoming <-chan (<-chan T)) <
 // FanInWithContext returns unbuffered channel of generic type `T` which serves as
 // delivery pipeline for the values received from at least 2 incoming channels,
 // its closed once all of the incoming channels closed or context cancelled.
-func FanInWithContext[T any](ctx context.Context, ch1, ch2 <-chan T, channels ...<-chan T) <-chan T {
+func FanInWithContext[T any](ctx context.Context, ch1, ch2 <-chan T, channels ...<-chan T) (<-chan T, error) {
+	if ctx == nil {
+		return nil, ErrContext
+	}
+
 	var wg sync.WaitGroup
 	ch := make(chan T)
 
@@ -70,7 +85,7 @@ func FanInWithContext[T any](ctx context.Context, ch1, ch2 <-chan T, channels ..
 		close(ch)
 	}()
 
-	return ch
+	return ch, nil
 }
 
 func passWithContext[T any](ctx context.Context, wg *sync.WaitGroup, out chan<- T, in <-chan T) {
@@ -100,7 +115,11 @@ func passWithContext[T any](ctx context.Context, wg *sync.WaitGroup, out chan<- 
 // FututeWithContext[T any] will return buffered channel of size 1 and generic type `T`,
 // which will eventually contain the results of the execution `futureFn``, or be closed
 // in case if context cancelled.
-func FututeWithContext[T any](ctx context.Context, futureFn func() T) <-chan T {
+func FututeWithContext[T any](ctx context.Context, futureFn func() T) (<-chan T, error) {
+	if ctx == nil {
+		return nil, ErrContext
+	}
+
 	ch := make(chan T, 1)
 
 	go func() {
@@ -117,7 +136,11 @@ func FututeWithContext[T any](ctx context.Context, futureFn func() T) <-chan T {
 // that serves as a pipeline for the incoming channel. Channel is closed once
 // the context is canceled or the incoming channel is closed. This is variation
 // or the pattern that usually called `OrWithDone` or`Cancel`.
-func OrWithContext[T any](ctx context.Context, incoming <-chan T) <-chan T {
+func OrWithContext[T any](ctx context.Context, incoming <-chan T) (<-chan T, error) {
+	if ctx == nil {
+		return nil, ErrContext
+	}
+
 	ch := make(chan T)
 
 	go func() {
@@ -142,7 +165,7 @@ func OrWithContext[T any](ctx context.Context, incoming <-chan T) <-chan T {
 		}
 	}()
 
-	return ch
+	return ch, nil
 }
 
 // --- Pipeline Pattern  -------------------------------------------------------
@@ -154,17 +177,21 @@ func OrWithContext[T any](ctx context.Context, incoming <-chan T) <-chan T {
 // closed once the incoming chan is closed or context canceld.
 func PipelineWithContext[T1, T2 any](
 	ctx context.Context,
-	incoming <-chan T1,
+	incomingCh <-chan T1,
 	totalWorkers int,
 	workerFn func(T1) T2,
-) <-chan T2 {
+) (<-chan T2, error) {
 
-	outgoing := make(chan T2)
+	if ctx == nil {
+		return nil, ErrContext
+	}
+
+	outgoingCH := make(chan T2)
 	workers := make(chan token, totalWorkers)
 
 	go func() {
 		// close outgoing channel
-		defer close(outgoing)
+		defer close(outgoingCH)
 
 		// wait for each worker to finish work.
 		defer func() {
@@ -179,7 +206,7 @@ func PipelineWithContext[T1, T2 any](
 			select {
 			case <-ctx.Done():
 				return
-			case tmp, ok := <-incoming:
+			case tmp, ok := <-incomingCh:
 				if !ok {
 					return
 				}
@@ -188,13 +215,13 @@ func PipelineWithContext[T1, T2 any](
 
 			workers <- token{}
 			go func() {
-				outgoing <- workerFn(job)
+				outgoingCH <- workerFn(job)
 				<-workers
 			}()
 		}
 	}()
 
-	return outgoing
+	return outgoingCH, nil
 }
 
 // --- Queue Pattern -----------------------------------------------------------
@@ -202,7 +229,11 @@ func PipelineWithContext[T1, T2 any](
 // QueueWithContext returns an unbuffered channel that is populated by
 // func `genFn`. Chan is closed once context is Done. It's similar to `Future`
 // pattern, but doesn't have a limit to just one result.
-func QueueWithContext[T any](ctx context.Context, genFn func() T) <-chan T {
+func QueueWithContext[T any](ctx context.Context, genFn func() T) (<-chan T, error) {
+	if ctx == nil {
+		return nil, ErrContext
+	}
+
 	ch := make(chan T)
 
 	go func() {
@@ -217,7 +248,7 @@ func QueueWithContext[T any](ctx context.Context, genFn func() T) <-chan T {
 		}
 	}()
 
-	return ch
+	return ch, nil
 }
 
 // --- Tee Pattern -------------------------------------------------------------
@@ -225,14 +256,19 @@ func QueueWithContext[T any](ctx context.Context, genFn func() T) <-chan T {
 // TeeWithContext will return two channels of generic type `T` used to fan-out
 // data from the incoming channel. Channels needs to be read in order next
 // iteration over incoming chanel happen.
-func TeeWithContext[T any](ctx context.Context, incoming <-chan T) (<-chan T, <-chan T) {
+func TeeWithContext[T any](ctx context.Context, incoming <-chan T) (<-chan T, <-chan T, error) {
+	incomingCh, err := OrWithContext(ctx, incoming)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	ch1, ch2 := make(chan T), make(chan T)
 
 	go func() {
 		defer close(ch1)
 		defer close(ch2)
 
-		for val := range OrWithContext(ctx, incoming) {
+		for val := range incomingCh {
 			ch1, ch2 := ch1, ch2
 			for i := 0; i < 2; i++ {
 				select {
@@ -249,7 +285,7 @@ func TeeWithContext[T any](ctx context.Context, incoming <-chan T) (<-chan T, <-
 		}
 	}()
 
-	return ch1, ch2
+	return ch1, ch2, nil
 }
 
 // --- WorkerPool Pattern  -----------------------------------------------------
@@ -262,7 +298,12 @@ func WorkerPoolWithContext[T any](
 	jobQueue chan T,
 	maxWorkers int,
 	workFunc func(T),
-) {
+) error {
+
+	if ctx == nil {
+		return ErrContext
+	}
+
 	busyWorkers := make(chan token, maxWorkers) // semaphore for the workers
 
 	go func() {
@@ -295,4 +336,6 @@ func WorkerPoolWithContext[T any](
 			}()
 		}
 	}()
+
+	return nil
 }

--- a/with_context.go
+++ b/with_context.go
@@ -60,7 +60,7 @@ func BridgeWithContext[T any](
 
 // FanInWithContext returns unbuffered channel of generic type `T` which serves as
 // delivery pipeline for the values received from at least 2 incoming channels,
-// its closed once all of the incoming channels closed or context cancelled.
+// it's closed once all of the incoming channels closed or context cancelled.
 func FanInWithContext[T any](ctx context.Context, ch1, ch2 <-chan T, channels ...<-chan T) (<-chan T, error) {
 	if ctx == nil {
 		return nil, ErrContext

--- a/with_context_test.go
+++ b/with_context_test.go
@@ -78,10 +78,10 @@ func TestFanInWithContext(t *testing.T) {
 
 			// given:
 			chOut, err := harmony.FanInWithContext(ctx,
-				generateNumberSequence(1, 10),
-				generateNumberSequence(1, 10),
-				generateNumberSequence(1, 10),
-				generateNumberSequence(1, 10),
+				generateNumberSequence(1, 100),
+				generateNumberSequence(1, 100),
+				generateNumberSequence(1, 100),
+				generateNumberSequence(1, 100),
 			)
 			if err != nil {
 				t.Errorf("fanin err: %v", err)
@@ -94,7 +94,7 @@ func TestFanInWithContext(t *testing.T) {
 			}
 
 			// then:
-			if (len(results) == 40) != test.expected {
+			if (len(results) == 400) != test.expected {
 				t.Errorf("unexpected: len(results) is %d", len(results))
 			}
 		})
@@ -310,7 +310,7 @@ func TestQueueWithContext(t *testing.T) {
 
 			want := []uint64{2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
 			if reflect.DeepEqual(want, powerRes) != test.expected {
-				t.Errorf("got %v vs want (%t)%v", powerRes, test.expected, want)
+				t.Errorf("got(%v) == want(%v) isn't %t", powerRes, want, test.expected)
 			}
 		})
 	}

--- a/with_done.go
+++ b/with_done.go
@@ -60,7 +60,7 @@ func BridgeWithDone[T any](
 
 // FanInWithDone returns unbuffered channel of generic type `T` which serves as
 // delivery pipeline for the values received from at least 2 incoming channels,
-// its closed once all of the incoming channels closed or done is closed
+// it's closed once all of the incoming channels closed or done is closed
 func FanInWithDone[T any](done <-chan struct{}, ch1, ch2 <-chan T, channels ...<-chan T) (<-chan T, error) {
 	if done == nil {
 		return nil, ErrDone

--- a/with_done_test.go
+++ b/with_done_test.go
@@ -78,10 +78,10 @@ func TestFanInWithDone(t *testing.T) {
 
 			// given:
 			chOut, err := harmony.FanInWithDone(done,
-				generateNumberSequence(1, 10),
-				generateNumberSequence(1, 10),
-				generateNumberSequence(1, 10),
-				generateNumberSequence(1, 10),
+				generateNumberSequence(1, 100),
+				generateNumberSequence(1, 100),
+				generateNumberSequence(1, 100),
+				generateNumberSequence(1, 100),
 			)
 			if err != nil {
 				t.Errorf("fanin err: %v", err)
@@ -94,7 +94,7 @@ func TestFanInWithDone(t *testing.T) {
 			}
 
 			// then:
-			if (len(results) == 40) != test.expected {
+			if (len(results) == 400) != test.expected {
 				t.Errorf("unexpected: len(results) is %d", len(results))
 			}
 		})
@@ -310,7 +310,7 @@ func TestQueueWithDone(t *testing.T) {
 
 			want := []uint64{2, 4, 8, 16, 32, 64, 128, 256, 512, 1024}
 			if reflect.DeepEqual(want, powerRes) != test.expected {
-				t.Errorf("got %v vs want (%t)%v", powerRes, test.expected, want)
+				t.Errorf("got(%v) == want(%v) isn't %t", powerRes, want, test.expected)
 			}
 		})
 	}


### PR DESCRIPTION
As matter of thing we had two options while handling possible nil arguments:
- [ ] panics (in case if context is nil)
- [x] handle error - a bit ugly API, and not possible to use functions as arguments to other functions,

